### PR TITLE
Fix syntax error

### DIFF
--- a/src/gmapsExtension.php
+++ b/src/gmapsExtension.php
@@ -95,8 +95,8 @@ class gmapsExtension extends SimpleExtension
 
     public function callbackSnippet()
     {
-        $container = $this->getContainer();
-        return '<script>var gapikey = "'.$container['config']->get('general/google_api_key').'"</script>';
+        $app = $this->getContainer();
+        return '<script>var gapikey = "'.$app['config']->get('general/google_api_key').'"</script>';
     }
 
     public function map(array $args = [])

--- a/src/gmapsExtension.php
+++ b/src/gmapsExtension.php
@@ -95,7 +95,8 @@ class gmapsExtension extends SimpleExtension
 
     public function callbackSnippet()
     {
-        return '<script>var gapikey = "'.($this->getContainer())['config']->get('general/google_api_key').'"</script>';
+        $container = $this->getContainer();
+        return '<script>var gapikey = "'.$container['config']->get('general/google_api_key').'"</script>';
     }
 
     public function map(array $args = [])


### PR DESCRIPTION
On PHP 5.5.38 I get a syntax error `unexpected '['` here. Not sure exactly why since array dereferencing was added in PHP 5.4. But this fixes it.